### PR TITLE
Add missing comma to `/settings/_variables.scss`.

### DIFF
--- a/settings/_variables.scss
+++ b/settings/_variables.scss
@@ -39,7 +39,8 @@ $container-max-widths: (
 // ============================================================
 $display-breakpoints: (
     print-only: 'only print',
-    screen-only: 'only screen' xs-only:
+    screen-only: 'only screen',
+    xs-only:
         'only screen and (max-width: #{(map-get($grid-breakpoints, sm) - 1)})',
     sm-only: 'only screen and (min-width: #{map-get($grid-breakpoints, sm)}) and ' +
         '(max-width: #{(map-get($grid-breakpoints, md)  - 1)})',


### PR DESCRIPTION
Fixes this error:
```
Module build failed (from ./node_modules/sass-loader/lib/loader.js):

    screen-only: 'only screen' xs-only:
                              ^
      Unclosed parenthesis
```